### PR TITLE
Fixed a typo in footer

### DIFF
--- a/web/src/components/Footer.tsx
+++ b/web/src/components/Footer.tsx
@@ -122,7 +122,7 @@ const Footer = () => {
       <div className="content has-text-centered">
         <p>
           {" "}
-          <a href="http://github.com/alemayhu/notion2anki/">This</a> is a open
+          <a href="http://github.com/alemayhu/notion2anki/">This</a> is an open
           source project by{" "}
           <a href="https://alemayhu.com">Alexander Alemayhu</a>{" "}
         </p>


### PR DESCRIPTION
Just saw and fixed a type in the footer:
a open source -> aN open source