### PR TITLE
removed mp3 url from cards

### DIFF
--- a/server/parser/DeckParser.ts
+++ b/server/parser/DeckParser.ts
@@ -503,6 +503,7 @@ export class DeckParser {
 
           const audiofile = this.getMP3File(card.back);
           if (audiofile) {
+            card.back = card.back.replace(/<figure.*<a\shref=["'].*\.mp3["']>.*<\/a>.*<\/figure>/ , "");
             const newFileName = this.embedFile(
               exporter,
               this.files,


### PR DESCRIPTION
- Removed mp3 url box from card.back, including the remaining empty figure
  - I tried it, the mp3 file can still be played. 

### Before
<img width="694" alt="2021-03-31 18_29_02-notion2anki - Anki" src="https://user-images.githubusercontent.com/68744864/113170239-0c37fe80-924f-11eb-9328-b50e4169427d.png">

### After
<img width="706" alt="2021-03-31 18_25_34-notion2anki - Anki" src="https://user-images.githubusercontent.com/68744864/113169692-861bb800-924e-11eb-9514-d36a22688296.png">

Fixes #82 