### PR TITLE
server/parser: fix bug where nested images got ignored

### DIFF
--- a/server/parser/DeckParser.ts
+++ b/server/parser/DeckParser.ts
@@ -324,7 +324,11 @@ export class DeckParser {
         /\.\.\//g,
         ""
       );
-      file = files.find((f) => f.name === lookup);
+      file = files.find((f) => {
+        if (f.name === lookup || f.name.endsWith(filePath)) {
+          return f;
+        }
+      });
       if (!file) {
         console.warn(
           `Missing relative path to ${filePath} used ${exporter.firstDeckName}`


### PR DESCRIPTION
Need to check if this is a potential regression but seems to work as
expected based on user sample.