### PR TITLE
fix broken wiki links

### DIFF
--- a/web/_redirects
+++ b/web/_redirects
@@ -1,8 +1,8 @@
 /* https://2anki.net/:splat
 
-/benefits* https://www.notion.so/alemayhu/Benefits-0d5fa2e18a8a44d782c72945b2bd413b
-/privacy* https://www.notion.so/alemayhu/Privacy-38c6e8238ac04ea9b2485bf488909fd0
-/faq* https://www.notion.so/alemayhu/FAQ-ef01be9c9bac41689a4d749127c14301
-/contact* https://www.notion.so/alemayhu/Contact-e76523187cc64961972b3ad4f7cb4c47
-/links* https://www.notion.so/alemayhu/Useful-Links-0f3051946a2d4b71ae31610da76b28a8
-/useful-links* https://www.notion.so/alemayhu/Useful-Links-0f3051946a2d4b71ae31610da76b28a8
+/benefits* https://alemayhu.notion.site/Benefits-0d5fa2e18a8a44d782c72945b2bd413b
+/privacy* https://alemayhu.notion.site/Privacy-38c6e8238ac04ea9b2485bf488909fd0
+/faq* https://alemayhu.notion.site/FAQ-ef01be9c9bac41689a4d749127c14301
+/contact* https://alemayhu.notion.site/Contact-e76523187cc64961972b3ad4f7cb4c47
+/links* https://alemayhu.notion.site/Useful-Links-0f3051946a2d4b71ae31610da76b28a8
+/useful-links* https://alemayhu.notion.site/Useful-Links-0f3051946a2d4b71ae31610da76b28a8

--- a/web/src/components/Footer.tsx
+++ b/web/src/components/Footer.tsx
@@ -27,7 +27,7 @@ const Footer = () => {
             <a
               rel="noreferrer"
               target="_blank"
-              href="https://www.notion.so/alemayhu/Benefits-0d5fa2e18a8a44d782c72945b2bd413b"
+              href="https://alemayhu.notion.site/Benefits-0d5fa2e18a8a44d782c72945b2bd413b"
             >
               Benefits
             </a>
@@ -36,7 +36,7 @@ const Footer = () => {
             <a
               rel="noreferrer"
               target="_blank"
-              href="https://www.notion.so/alemayhu/Privacy-38c6e8238ac04ea9b2485bf488909fd0"
+              href="https://alemayhu.notion.site/Privacy-38c6e8238ac04ea9b2485bf488909fd0"
             >
               Privacy
             </a>
@@ -45,7 +45,7 @@ const Footer = () => {
             <a
               rel="noreferrer"
               target="_blank"
-              href="https://www.notion.so/alemayhu/FAQ-ef01be9c9bac41689a4d749127c14301"
+              href="https://alemayhu.notion.site/FAQ-ef01be9c9bac41689a4d749127c14301"
             >
               FAQ
             </a>

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -99,7 +99,7 @@ const HomePage = () => {
           Below are some selected videos to get you started with the project and
           see some common use cases. If you have any questions, do not hesistate
           to ask questions (see{" "}
-          <a href="https://www.notion.so/Contact-e76523187cc64961972b3ad4f7cb4c47">
+          <a href="https://alemayhu.notion.site/Contact-e76523187cc64961972b3ad4f7cb4c47">
             contact
           </a>{" "}
           page).


### PR DESCRIPTION
They must have broken after enabling the custom subdomains on Notion. 

Thanks to Esry on Discord reporting it.