### PR TITLE
Get integration tests passing

### DIFF
--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -21,7 +21,7 @@ jobs:
           npm install -g pnpm
           pnpm --dir server install
           pnpm --dir server run build
-          pip3 install -U setuptools 
+          python3 -m pip install --upgrade pip wheel setuptools
           pip3 install -r server/genanki/requirements.txt
           pnpm --dir server run test
         env:

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+          python-version: "3.9"
       - name: test
         run: |
           npm install -g pnpm

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -11,6 +11,9 @@ jobs:
         node-version: [15.0.1]
 
     steps:
+      - name: python version check
+        run: |
+          /usr/bin/python3 --version
       - uses: actions/checkout@v1
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -21,7 +21,7 @@ jobs:
           npm install -g pnpm
           pnpm --dir server install
           pnpm --dir server run build
-          pip3 install setuptools=33.1.1
+          pip3 install setuptools==33.1.1
           pip3 install -r server/genanki/requirements.txt
           pnpm --dir server run test
         env:

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -11,10 +11,7 @@ jobs:
         node-version: [15.0.1]
 
     steps:
-      - uses: actions/setup-python@v2
-        with:
-          python-version: "3.9"
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -12,6 +12,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -11,9 +11,6 @@ jobs:
         node-version: [15.0.1]
 
     steps:
-      - name: python version check
-        run: |
-          /usr/bin/python3 --version
       - uses: actions/checkout@v1
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -11,12 +11,14 @@ jobs:
         node-version: [15.0.1]
 
     steps:
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
       - uses: actions/checkout@v1
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-          python-version: "3.9"
       - name: test
         run: |
           npm install -g pnpm

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -12,9 +12,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: "3.9"
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
@@ -24,7 +21,7 @@ jobs:
           npm install -g pnpm
           pnpm --dir server install
           pnpm --dir server run build
-          python3 -m pip install --upgrade pip wheel setuptools
+          pip3 install setuptools=33.1.1
           pip3 install -r server/genanki/requirements.txt
           pnpm --dir server run test
         env:

--- a/server/genanki/requirements.txt
+++ b/server/genanki/requirements.txt
@@ -1,4 +1,4 @@
 # make sure to update the alemayhu/base-image-n2a
 # and pull it in the live server: ssh root@2anki.net docker pull alemayhu/base-image-n2a
 # It's using notion2anki as a submodule.
-genanki==0.10.0
+genanki==0.11.0


### PR DESCRIPTION
Unfortunately we have to lock the `setuptools` versions. Newer ones are causing build errors. 