### PR TITLE
server: run migrations programmatically

### DIFF
--- a/server/knexfile.ts
+++ b/server/knexfile.ts
@@ -1,50 +1,17 @@
-// Update with your config settings.
+import { Knex } from "knex";
 
-module.exports = {
-  development: {
-    client: "postgresql",
-    connection: {
-      database: "n",
-      user: "aa",
-      password: "focaccia",
-    },
-    pool: {
-      min: 2,
-      max: 10,
-    },
-    migrations: {
-      tableName: "knex_migrations",
-    },
+const config: Knex.Config = {
+  client: "pg",
+  connection:
+    process.env.DATABASE_URL || "postgresql://aa:focaccia@localhost:5432/n",
+  pool: {
+    min: 2,
+    max: 10,
   },
-
-  staging: {
-    client: "postgresql",
-    connection: {
-      charset: "utf8",
-      host: process.env.DB_HOST,
-      port: process.env.DB_PORT,
-      database: process.env.DB_NAME,
-      user: process.env.DB_USERNAME,
-      password: process.env.DB_PASSWORD,
-    },
-    pool: {
-      min: 2,
-      max: 10,
-    },
-    migrations: {
-      tableName: "knex_migrations",
-    },
-  },
-
-  production: {
-    client: "postgresql",
-    connection: process.env.DATABASE_URL,
-    pool: {
-      min: 2,
-      max: 10,
-    },
-    migrations: {
-      tableName: "knex_migrations",
-    },
+  migrations: {
+    tableName: "knex_migrations",
+    directory: "migrations",
   },
 };
+
+export default config;

--- a/server/package.json
+++ b/server/package.json
@@ -26,8 +26,7 @@
     "build": "tsc -p .",
     "dev": " WORKSPACE_BASE=/tmp/w nodemon --watch '**/*.ts' --exec \"ts-node\" server.ts",
     "lint": "tslint -c tslint.json '**/*.ts'",
-    "purge-js": "rm `find . -name '*.js'|grep -v node_modules`",
-    "migrate": "knex migrate:latest --env production"
+    "purge-js": "rm `find . -name '*.js'|grep -v node_modules`"
   },
   "repository": {
     "type": "git",

--- a/server/server.ts
+++ b/server/server.ts
@@ -20,6 +20,7 @@ import * as upload from "./routes/upload";
 import * as users from "./routes/users";
 
 import DB from "./storage/db";
+import config from "./knexfile";
 
 // Make sure the workspace area exists for processing
 if (!process.env.WORKSPACE_BASE) {
@@ -145,10 +146,13 @@ function serve() {
   DB.raw("SELECT 1").then(() => {
     console.log("DB is ready");
   });
-  process.env.SECRET ||= "victory";
-  const port = process.env.PORT || 2020;
-  app.listen(port, () => {
-    console.log(`🟢 Running on http://localhost:${port}`);
+  /* @ts-ignore */
+  DB.migrate.latest(config).then(() => {
+    process.env.SECRET ||= "victory";
+    const port = process.env.PORT || 2020;
+    app.listen(port, () => {
+      console.log(`🟢 Running on http://localhost:${port}`);
+    });
   });
 }
 


### PR DESCRIPTION
It turns out that the environment variables are not available during
build time. So we need to run the migrations later when we actually have
the environment during run time.