### PR TITLE
server: use MIGRATIONS_DIR if set

### DIFF
--- a/server/knexfile.ts
+++ b/server/knexfile.ts
@@ -10,7 +10,7 @@ const config: Knex.Config = {
   },
   migrations: {
     tableName: "knex_migrations",
-    directory: "migrations",
+    directory: process.env.MIGRATIONS_DIR || "migrations",
   },
 };
 


### PR DESCRIPTION
The current working directory is different. We can't rely on it being
relative.